### PR TITLE
allow init() to be called with a json object

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -3686,6 +3686,8 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 			} else {
 				if (type.of(d) == "string") {
 					VMM.Timeline.DataObj.getData(d);
+				} else if (type.of(d) == 'object' && d.timeline.type == "default") { // we got a JSON object passed in, let's go!
+					VMM.fireEvent(global, "DATAREADY", d);
 				} else {
 					VMM.Timeline.DataObj.getData(html_string);
 					//VMM.attachElement(element, content);


### PR DESCRIPTION
Sorry I messed the last one up. I don't do much fork/branch/pull stuff.

This allows init() to take a parsed JSON object. I'm using it to pull down a JSONP-wrapped WordPress query, rewrite it, then init the timeline. There's a demo here: http://ivarvong.com/timeline/url.html?query=topics/chip-kelly/
