### PR TITLE
Expose TimeNav.setMarker Publicly via the Timeline object.

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -2804,11 +2804,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Slider == 'undefined') {
 				VMM.Element.stop($slider_container);
 				VMM.Element.animate($slider_container, _duration, _ease, {"left": -(_pos.left - config.content_padding)});
 			}
-			
-			if (firstrun) {
-				VMM.fireEvent(layout, "LOADED");
-			}
-			
+
 			/* SET Vertical Scoll
 			================================================== */
 			//opacitySlides(0.85);


### PR DESCRIPTION
It's useful to be able to navigate the timeline programmatically (e.g. in order to link to specific event in the timeline, to autoscroll the timeline, etc.). This pull requests exposes the TimeNav.setMarker method publicly via the Timline object.
