### PR TITLE
Dynamic present day and time for endDate

### DIFF
--- a/source/js/Core/VMM.Date.js
+++ b/source/js/Core/VMM.Date.js
@@ -92,11 +92,23 @@ if(typeof VMM != 'undefined' && typeof VMM.Date == 'undefined') {
 					if (	date_array[2]			) {	date.setFullYear(		date_array[2]);			}
 					if (	date_array[0]	> 1		) {	date.setMonth(			date_array[0] - 1);		}
 					if (	date_array[1]	> 1		) {	date.setDate(			date_array[1]);			}
-				} else if (d == "present" || d == "-") {
-					var now = new Date();
-					date.setFullYear(now.getFullYear());
-					date.setMonth(now.getMonth());
-					date.setDate(now.getDate());
+				} else if (d.match("now")) {
+				    var now = new Date();                   
+				    date.setFullYear(now.getFullYear());
+				    date.setMonth(now.getMonth());
+				    date.setDate(now.getDate());
+				    if (d.match("hours")) {
+				        date.setHours(now.getHours());
+				    }
+				    if (d.match("minutes")) {
+				        date.setMinutes(now.getMinutes());
+				    }
+				    if (d.match("seconds")) {
+				        date.setSeconds(now.getSeconds());
+				    }
+				    if (d.match("milliseconds")) {
+				        date.setMilliseconds(now.getMilliseconds());
+				    }
 				} else if (d.length <= 5) {
 					date.setFullYear(parseInt(d, 10));
 					date.setMonth(0);


### PR DESCRIPTION
You can use "now" flag for end date so current era will dynamically change to current day (e.g. current employment). Specify whether or not using time with "now [hours] [minutes] [seconds] [milliseconds]" flags.
