### PR TITLE
Escape `.`-character for proper matching.

### DIFF
--- a/source/js/VMM.Timeline.DataObj.js
+++ b/source/js/VMM.Timeline.DataObj.js
@@ -22,7 +22,7 @@ if (typeof VMM.Timeline !== 'undefined' && typeof VMM.Timeline.DataObj == 'undef
 					trace("DATA SOURCE: STORIFY");
 					VMM.Timeline.DataObj.model.storify.getData(raw_data);
 					//http://api.storify.com/v1/stories/number10gov/g8-and-nato-chicago-summit
-				} else if (raw_data.match(".jsonp")) {
+				} else if (raw_data.match("\.jsonp")) {
 					trace("DATA SOURCE: JSONP");
 					LoadLib.js(raw_data, VMM.Timeline.DataObj.onJSONPLoaded);
 				} else {


### PR DESCRIPTION
Current regex, raw_data.match(".jsonp") would match any string that
contains "jsonp" with at least one preceding character, as . is
treated as a wild card. Escaping the . makes sure we only match
the actual string ".jsonp".
