### PR TITLE
Interpret Google Maps Streetview API URLs correctly

### DIFF
--- a/source/js/Core/Media/VMM.MediaType.js
+++ b/source/js/Core/Media/VMM.MediaType.js
@@ -69,7 +69,7 @@ if(typeof VMM != 'undefined' && typeof VMM.MediaType == 'undefined') {
 			}
 			media.type = "twitter";
 			success = true;
-		} else if (d.match("maps.google") && !d.match("staticmap")) {
+		} else if (d.match("maps.google") && !d.match("staticmap") && !d.match("streetview")) {
 			media.type = "google-map";
 		    media.id = d.split(/src=['|"][^'|"]*?['|"]/gi);
 			success = true;
@@ -94,7 +94,7 @@ if(typeof VMM != 'undefined' && typeof VMM.MediaType == 'undefined') {
 			media.link = d;
 			media.id = d.split("\/p\/")[1].split("/")[0];
 			success = true;
-		} else if (d.match(/jpg|jpeg|png|gif/i) || d.match("staticmap") || d.match("yfrog.com") || d.match("twitpic.com")) {
+		} else if (d.match(/jpg|jpeg|png|gif/i) || d.match("staticmap") || d.match("yfrog.com") || d.match("twitpic.com") || d.match("maps.googleapis.com/maps/api/streetview")) {
 			media.type = "image";
 			media.id = d;
 			success = true;


### PR DESCRIPTION
Google Maps Streetview API URLs return images and should be classified thusly.  This commit narrows the conditional for the google-map media type and widens the conditional for the image media type.
