### PR TITLE
Load jQuery fix for Embed.js

### DIFF
--- a/source/js/Core/Embed/Embed.js
+++ b/source/js/Core/Embed/Embed.js
@@ -231,13 +231,15 @@ function createStoryJS(c, src) {
 	    ready.has_jquery = jQuery;
 	    ready.has_jquery = true;
 		if (ready.has_jquery) {
-			var jquery_version = parseFloat(jQuery.fn.jquery);
-			if (jquery_version < parseFloat(jquery_version_required) ) {
-				//console.log("NOT THE REQUIRED VERSION OF JQUERY, LOADING THE REQUIRED VERSION");
-				//console.log("YOU HAVE VERSION " + jQuery.fn.jquery + ", JQUERY VERSION " + jquery_version_required + " OR ABOVE NEEDED");
-				ready.jquery = false;
-			} else {
-				ready.jquery = true;
+			var jquery_version_array = jQuery.fn.jquery.split(".");
+			var jquery_version_required_array = jquery_version_required.split(".");
+			ready.jquery = true;
+			for (i = 0; i < 2; i++) {
+				if (parseFloat(jquery_version_array[i]) < parseFloat(jquery_version_required_array[i])) {
+					//console.log("NOT THE REQUIRED VERSION OF JQUERY, LOADING THE REQUIRED VERSION");
+					//console.log("YOU HAVE VERSION " + jQuery.fn.jquery + ", JQUERY VERSION " + jquery_version_required + " OR ABOVE NEEDED");
+					ready.jquery = false;
+				}
 			}
 		}
 	} catch(err) {


### PR DESCRIPTION
Fixes the logic for determining if the loaded version of jQuery is a least the required version of jQuery. It was parsing version 1.10.2 as 1.1 which made it think that the current version was less the required version 1.7.1, thus loading another version of jQuery and causing conflict issues.
