### PR TITLE
Fixed function untagify to remove close tag

### DIFF
--- a/source/js/Core/Core/VMM.Util.js
+++ b/source/js/Core/Core/VMM.Util.js
@@ -286,7 +286,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Util == 'undefined') {
 			if (!text) {
 				return text;
 			}
-			text = text.replace(/<\s*\w.*?>/g,"");
+			text = text.replace(/<\/?\s*\w.*?>/g,"");
 			return text;
 		},
 		


### PR DESCRIPTION
untagify didn't remove a close tag, so if you have html headline <div>Text</div>

you'll get Text</div>

It breaks html structure, and causes headlines not showing in timeline slider in IE8
