### PR TITLE
Support for Hashbang (#!) Slide URLS To comply with Google AJAX Crawling guidelines

### DIFF
--- a/source/js/VMM.Timeline.js
+++ b/source/js/VMM.Timeline.js
@@ -67,6 +67,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 			preload:				4,
 			current_slide:			0,
 			hash_bookmark:			false,
+            use_hashbang:           false,
 			start_at_end: 			false,
 			start_at_slide:			0,
 			start_zoom_adjust:		0,
@@ -149,15 +150,21 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 		}
 		
 		if(window.location.hash) {
-			 var hash					=	window.location.hash.substring(1);
+			 var hash					=	(config.use_hashbang) 
+                ? window.location.hash.substring(2) 
+                : window.location.hash.substring(1);
+
 			 if (!isNaN(hash)) {
 			 	 config.current_slide	=	parseInt(hash);
 			 }
 		}
 		
 		window.onhashchange = function () {
-			var hash					=	window.location.hash.substring(1);
-			if (config.hash_bookmark) {
+			 var hash					=	(config.use_hashbang) 
+                ? window.location.hash.substring(2) 
+                : window.location.hash.substring(1);
+			
+            if (config.hash_bookmark) {
 				if (is_moving) {
 					goToEvent(parseInt(hash));
 				} else {
@@ -320,7 +327,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 		
 		function setHash(n) {
 			if (config.hash_bookmark) {
-				window.location.hash = "#" + n.toString();
+				window.location.hash = "#" + ((config.use_hashbang)? "!" : "") +  n.toString();
 			}
 		}
 		

--- a/source/js/VMM.Timeline.js
+++ b/source/js/VMM.Timeline.js
@@ -67,7 +67,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 			preload:				4,
 			current_slide:			0,
 			hash_bookmark:			false,
-            use_hashbang:           false,
+			use_hashbang:           false,
 			start_at_end: 			false,
 			start_at_slide:			0,
 			start_zoom_adjust:		0,
@@ -160,11 +160,11 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 		}
 		
 		window.onhashchange = function () {
-			 var hash					=	(config.use_hashbang) 
+			var hash					=	(config.use_hashbang) 
                 ? window.location.hash.substring(2) 
                 : window.location.hash.substring(1);
 			
-            if (config.hash_bookmark) {
+			if (config.hash_bookmark) {
 				if (is_moving) {
 					goToEvent(parseInt(hash));
 				} else {
@@ -695,3 +695,4 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 	VMM.Timeline.Config = {};
 	
 };
+


### PR DESCRIPTION
Hey,
I've added a very simple option, 'use_hashbang', that when used in combination with hash_bookmark, will produce slide hash URLs that are compliant with Google's AJAX crawling guidelines, making it possible for site admins to supply static HTML versions of the individual slide pages. This is a simple change and I believe would benefit many site owners who'd opt to use this library on their site. For more info on Google's AJAX Crawling scheme see here:

https://developers.google.com/webmasters/ajax-crawling/docs/getting-started
