### PR TITLE
Updated iframe regex for MediaType detection

### DIFF
--- a/source/js/Core/Media/VMM.MediaType.js
+++ b/source/js/Core/Media/VMM.MediaType.js
@@ -124,7 +124,7 @@ if(typeof VMM != 'undefined' && typeof VMM.MediaType == 'undefined') {
 		} else if (d.match('iframe')) {
 			media.type = "iframe";
 			trace("IFRAME")
-			regex = /src=['"](\S+?)['"]\s/;
+			regex = /src=['"](\S+?)['"](\s|>)/;
 			group = d.match(regex);
 			if (group) {
 				media.id = group[1];


### PR DESCRIPTION
The previous regex required the iframe to have an attribute after "src", so <iframe src="..."></iframe> didn't work, but things like <iframe src="..." frameborder="no"></iframe> did. Since only the src is used and the rest of the iframe is reconstructed, there's no need for extra attributes, and had me searching for a bit.
