### PR TITLE
Show IE 8+ compatibility mode users a better error

### DIFF
--- a/source/js/VMM.Timeline.js
+++ b/source/js/VMM.Timeline.js
@@ -486,7 +486,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 			// IE7
 			if (ie7) {
 				ie7 = true;
-				VMM.fireEvent(global, config.events.messege, "Internet Explorer " + VMM.Browser.version + " is not supported by TimelineJS. Please update your browser to version 8 or higher.");
+				VMM.fireEvent(global, config.events.messege, "Internet Explorer " + VMM.Browser.version + " is not supported by TimelineJS. Please update your browser to version 8 or higher. If you are using a recent version of Internet Explorer you may need to disable compatibility mode in your browser.");
 			} else {
 				
 				detachMessege();


### PR DESCRIPTION
- Currently IE 8,9,10,11 etc users will see an 'IE 7 is not supported' message if they try and view a timeline while IE's compatibility mode is enabled.
- This is confusing as the user knows they are not using IE7.
- This commit alters the error message to include the sentence 'If you are using a recent version of Internet Explorer you may need to disable compatibility mode in your browser.'
- I haven't provided a link to guidance on how to do this as there doesn't seem to be an official Microsoft source on how to _disable_ compatibility mode, and I didn't want to link to an unofficial source that might become unavailable in the future.
