### PR TITLE
Added maxheight=168 directive for soundcloud iframes

### DIFF
--- a/source/js/Core/Media/VMM.ExternalAPI.js
+++ b/source/js/Core/Media/VMM.ExternalAPI.js
@@ -1259,7 +1259,7 @@ if(typeof VMM != 'undefined' && typeof VMM.ExternalAPI == 'undefined') {
 			},
 			
 			create: function(m, callback) {
-				var the_url = "//soundcloud.com/oembed?url=" + m.id + "&format=js&callback=?";
+				var the_url = "//soundcloud.com/oembed?url=" + m.id + "&maxheight=168&format=js&callback=?";
 				VMM.getJSON(the_url, function(d) {
 					VMM.attachElement("#"+m.uid, d.html);
 					callback();


### PR DESCRIPTION
Requests that soundcloud render an iframe with a maxheight of 168.
Without this, you end up with a very tall soundcloud iframe which hides
the timeline dropshadow and caption.
