### PR TITLE
Update zh-cn.js

### DIFF
--- a/source/js/Core/Language/locale/zh-cn.js
+++ b/source/js/Core/Language/locale/zh-cn.js
@@ -7,8 +7,8 @@ if(typeof VMM != 'undefined') {
 			wikipedia: "zh"
 		},
 		date: {
-			month: ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"],
-			month_abbr: ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"],
+			month: ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"],
+			month_abbr: ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"],
 			day: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"],
 			day_abbr: ["周日", "周一", "周二", "周三", "周四", "周五", "周六"]
 		}, 
@@ -16,7 +16,7 @@ if(typeof VMM != 'undefined') {
 			year: "yyyy年",
 			month_short: "mmm",
 			month: "yyyy年 mmmm",
-			full_short: "mmm d",
+			full_short: "mmm d日",
 			full: "yyyy年mmmm d日",
 			time_short: "HH:MM:ss",
 			time_no_seconds_short: "HH:MM",


### PR DESCRIPTION
I've converted the chinese characters for the numeric month back to numbers, as it is more consistent with the way the date is shown, with the numeric year and numeric day.
