### PR TITLE
Always CSS transitions when available

### DIFF
--- a/source/js/Core/Core/VMM.Browser.js
+++ b/source/js/Core/Core/VMM.Browser.js
@@ -12,12 +12,17 @@ if(typeof VMM != 'undefined' && typeof VMM.Browser == 'undefined') {
 			this.OS = this.searchString(this.dataOS) || "an unknown OS";
 			this.device = this.searchDevice(navigator.userAgent);
 			this.orientation = this.searchOrientation(window.orientation);
+			this.features = {
+				css: {
+					transitions: this.cssTransitionSupport()
+				}
+			};
 		},
 		searchOrientation: function(orientation) {
 			var orient = "";
-			if ( orientation == 0  || orientation == 180) {  
+			if ( orientation == 0  || orientation == 180) {
 				orient = "portrait";
-			} else if ( orientation == 90 || orientation == -90) {  
+			} else if ( orientation == 90 || orientation == -90) {
 				orient = "landscape";
 			} else {
 				orient = "normal";
@@ -155,8 +160,29 @@ if(typeof VMM != 'undefined' && typeof VMM.Browser == 'undefined') {
 				subString: "Linux",
 				identity: "Linux"
 			}
-		]
+		],
+		cssTransitionSupport: function () {
+			// See https://gist.github.com/jackfuchs/556448
+			var b = document.body || document.documentElement,
+			s = b.style,
+			p = 'transition';
 
-	}
+			if (typeof s[p] == 'string') {
+				return true;
+			}
+
+			// Tests for vendor specific prop
+			var v = ['Moz', 'webkit', 'Webkit', 'Khtml', 'O', 'ms'];
+			p = p.charAt(0).toUpperCase() + p.substr(1);
+
+			for (var i=0; i<v.length; i++) {
+				if (typeof s[v[i] + p] == 'string') {
+					return true;
+				}
+			}
+
+			return false;
+		}
+	};
 	VMM.Browser.init();
 }

--- a/source/js/Core/Core/VMM.Library.js
+++ b/source/js/Core/Core/VMM.Library.js
@@ -429,7 +429,7 @@ if(typeof VMM != 'undefined') {
 		},
 		
 		delay_animate: function(delay, element, duration, ease, att, callback_function) {
-			if (VMM.Browser.device == "mobile" || VMM.Browser.device == "tablet") {
+			if (VMM.Browser.features.css.transitions) {
 				var _tdd		= Math.round((duration/1500)*10)/10,
 					__duration	= _tdd + 's';
 					
@@ -477,10 +477,10 @@ if(typeof VMM != 'undefined') {
 			} else {
 				_att = {opacity: 0}
 			}
-			
-			
-			if (VMM.Browser.device == "mobile" || VMM.Browser.device == "tablet") {
-				
+
+
+			if (VMM.Browser.features.css.transitions) {
+
 				var _tdd		= Math.round((_duration/1500)*10)/10,
 					__duration	= _tdd + 's';
 					

--- a/source/js/Core/Core/VMM.Library.js
+++ b/source/js/Core/Core/VMM.Library.js
@@ -452,8 +452,8 @@ if(typeof VMM != 'undefined') {
 			var _ease		= "easein",
 				_que		= false,
 				_duration	= 1000,
-				_att		= {};
-			
+				_att;
+
 			if (duration != null) {
 				if (duration < 1) {
 					_duration = 1;
@@ -473,9 +473,9 @@ if(typeof VMM != 'undefined') {
 			
 			
 			if (att != null) {
-				_att = att
+				_att = att;
 			} else {
-				_att = {opacity: 0}
+				_att = {opacity: 0};
 			}
 
 			if (VMM.Browser.features.css.transitions && !('scrollTop' in _att)) {

--- a/source/js/Core/Core/VMM.Library.js
+++ b/source/js/Core/Core/VMM.Library.js
@@ -280,28 +280,27 @@ if(typeof VMM != 'undefined') {
 				}
 			}
 		},
-		
+
 		prop: function(element, aName, value) {
-			if (typeof jQuery == 'undefined' || !/[1-9]\.[3-9].[1-9]/.test(jQuery.fn.jquery)) {
-			    VMM.Lib.attribute(element, aName, value);
+			if (typeof jQuery == 'undefined' || !('prop' in jQuery.fn)) {
+			    return VMM.Lib.attribute(element, aName, value);
+			} else if (typeof value != 'undefined') {
+				return jQuery(element).prop(aName, value);
 			} else {
-				jQuery(element).prop(aName, value);
+				return jQuery(element).prop(aName);
 			}
 		},
-		
+
 		attribute: function(element, aName, value) {
-			
-			if (value != null && value != "") {
-				if( typeof( jQuery ) != 'undefined' ){
-					jQuery(element).attr(aName, value);
-				}
-			} else {
-				if( typeof( jQuery ) != 'undefined' ){
+			if (typeof(jQuery) != 'undefined') {
+				if (typeof(value) != 'undefined' && value != null && value != "") {
+					return jQuery(element).attr(aName, value);
+				} else {
 					return jQuery(element).attr(aName);
 				}
 			}
 		},
-		
+
 		visible: function(element, show) {
 			if (show != null) {
 				if( typeof( jQuery ) != 'undefined' ){

--- a/source/js/Core/Core/VMM.Library.js
+++ b/source/js/Core/Core/VMM.Library.js
@@ -484,7 +484,7 @@ if(typeof VMM != 'undefined') {
 					
 				_ease = " cubic-bezier(0.33, 0.66, 0.66, 1)";
 				//_ease = " ease-in-out";
-				for (x in _att) {
+				for (var x in _att) {
 					if (Object.prototype.hasOwnProperty.call(_att, x)) {
 						trace(x + " to " + _att[x]);
 						VMM.Lib.css(element, '-webkit-transition',  x + ' ' + __duration + _ease);

--- a/source/js/Core/Core/VMM.Library.js
+++ b/source/js/Core/Core/VMM.Library.js
@@ -427,9 +427,10 @@ if(typeof VMM != 'undefined') {
 				jQuery(element).stop();
 			}
 		},
-		
+
+		// TODO: Consider removing this as it's referenced by one commented line
 		delay_animate: function(delay, element, duration, ease, att, callback_function) {
-			if (VMM.Browser.features.css.transitions) {
+			if (VMM.Browser.features.css.transitions && !('scrollTop' in _att)) {
 				var _tdd		= Math.round((duration/1500)*10)/10,
 					__duration	= _tdd + 's';
 					
@@ -478,9 +479,7 @@ if(typeof VMM != 'undefined') {
 				_att = {opacity: 0}
 			}
 
-
-			if (VMM.Browser.features.css.transitions) {
-
+			if (VMM.Browser.features.css.transitions && !('scrollTop' in _att)) {
 				var _tdd		= Math.round((_duration/1500)*10)/10,
 					__duration	= _tdd + 's';
 					

--- a/source/js/Core/Slider/VMM.Slider.js
+++ b/source/js/Core/Slider/VMM.Slider.js
@@ -689,6 +689,8 @@ if(typeof VMM != 'undefined' && typeof VMM.Slider == 'undefined') {
 			} else {
 				VMM.Lib.css(layout, "overflow-y", "hidden" );
 				var scroll_height = 0;
+
+                // FIXME: Chrome cannot optimize this try/catch block, which appears to be unnecessary – see https://github.com/NUKnightLab/TimelineJS/pull/681#issuecomment-52365420
 				try {
 					scroll_height = VMM.Lib.prop(layout, "scrollHeight");
 					VMM.Lib.animate(layout, _duration, _ease, {scrollTop: scroll_height - VMM.Lib.height(layout) });


### PR DESCRIPTION
This makes a huge difference in perceptual animation quality from ~10-20 FPS on a 1.7Ghz Core i7 to 60FPS.

I'm working on a few more changes – I think we can avoid a number of invalidate/recalc cycles which would be a big win on mobile – but wanted to send this over because it's a small change and it might a good time to review the animation strategy now that CSS transition support is [well over 80% and climbing](http://caniuse.com/#feat=css-transitions) as people upgrade away from IE 8/9.