### PR TITLE
LESS: fix control positioning on RTL pages

### DIFF
--- a/source/less/Core/Typography.less
+++ b/source/less/Core/Typography.less
@@ -188,8 +188,12 @@
 /* Right to Left
  * ---------------------------------------------------------------------------------------- */
 .vco-storyjs.vco-right-to-left {
-	h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, cite, code, del, dfn, em, img, q, s, samp, small, strike, strong, 
+	[dir=rtl] &, &[dir=rtl] {
+		direction: ltr;
+	}
+
+	h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, cite, code, del, dfn, em, img, q, s, samp, small, strike, strong,
 	sub, sup, tt, var, dd, dl, dt, li, ol, ul, fieldset, form, label, legend, button, table, caption, tbody, tfoot, thead, tr, th, td,   {
-		direction:rtl;
+		direction: rtl;
 	}
 }


### PR DESCRIPTION
Currently the next and previous controls will overlap when embedded on an RTL page. This commit makes the controls usable but doesn’t start the larger project of flipping the various left/right classes applied to `.nav-next` and `.nav-previous` elements or updating the JavaScript to use “left” or “right” based on whether the timeline is embedded in a `dir=rtl` or `dir=ltr` element.

![screenshot 2014-08-21 11 39 26](https://cloud.githubusercontent.com/assets/46565/3998604/5c104bf4-2949-11e4-9b43-068c96a79239.png)