### PR TITLE
Remove HTTPS URL rewriting for older IE.

### DIFF
--- a/source/js/Core/Core/VMM.Library.js
+++ b/source/js/Core/Core/VMM.Library.js
@@ -131,22 +131,11 @@ if(typeof VMM != 'undefined') {
 			});
 			/* CHECK FOR IE
 			================================================== */
+      // Leaving for posterity - removed previous HTTPS url rewriting that was breaking IE9/10 loading data over HTTPS
 			if ( VMM.Browser.browser == "Explorer" && parseInt(VMM.Browser.version, 10) >= 7 && window.XDomainRequest) {
 				trace("IE JSON");
-				var ie_url = url;
-				if (ie_url.match('^http://')){
-					return jQuery.getJSON(ie_url, data, callback);
-				} else if (ie_url.match('^https://')) {
-					ie_url = ie_url.replace("https://","http://");
-					return jQuery.getJSON(ie_url, data, callback);
-				} else {
-					return jQuery.getJSON(url, data, callback);
-				}
-				
-			} else {
-				return jQuery.getJSON(url, data, callback);
-
 			}
+			return jQuery.getJSON(url, data, callback);
 		}
 	}
 	


### PR DESCRIPTION
This code was breaking loading data over HTTPS in IE9/10. Issue noticed loading data from Google Doc URL with Timeline.js under HTTPS.

I created a build locally for testing this fix (but am not committing build files yet, which would muck up this commit).

We had a timeline under HTTPS loading data from a Google Doc url (also HTTPS), which was failing to load data in IE9/10 and Android 2.3 - we were getting an Access Denied Error. We traced this back to this URL rewriting code.

Why was the secure URL being rewritten?
