### PR TITLE
Options for YouTube player

### DIFF
--- a/source/js/Core/Media/VMM.ExternalAPI.js
+++ b/source/js/Core/Media/VMM.ExternalAPI.js
@@ -1434,12 +1434,12 @@ if(typeof VMM != 'undefined' && typeof VMM.ExternalAPI == 'undefined') {
 					height: 				'390',
 					width: 					'640',
 					playerVars: {
-						enablejsapi:		1,
-						color: 				'white',
-						showinfo:			0,
-						theme:				'light',
-						start:				m.start,
-						rel:				0
+						enablejsapi: 1,
+						color: ("dark" == VMM.master_config.Timeline.youtubeTheme) ? "black" : "white",
+						showinfo: 0,
+						theme: ("undefined" !== VMM.master_config.Timeline.youtubeTheme) ? VMM.master_config.Timeline.youtubeTheme : "light",
+						start: m.start,
+						rel: 0
 					},
 					videoId: m.id,
 					events: {


### PR DESCRIPTION
Add a config option to change player style for dark.

Example:

``` js
// create timeline
timeline = createStoryJS({
    type: 'timeline',
    youtubeTheme: "dark", // "light"
    source: { ... }
});
```
