### PR TITLE
Prevents crashes...

### DIFF
--- a/build/js/timeline.js
+++ b/build/js/timeline.js
@@ -5265,6 +5265,10 @@ if(typeof VMM != 'undefined' && typeof VMM.Slider == 'undefined') {
 			
 			VMM.Lib.width($slides_items, (slides.length * config.slider.content.width));
 			
+			if(typeof current_slide == "undefined"){
+				current_slide = 0;
+			}
+			
 			if (_from_start) {
 				VMM.Lib.css($slider_container, "left", slides[current_slide].leftpos());
 			}


### PR DESCRIPTION
I'm working on creating simple data filters for my timeline JS implementation.  So far it's been pretty easy I'm just filtering the data on my page and calling the reload method.  However, if you use the reload function and are on a slide the current slide will get jacked up and cause a crash.  This prevents the crash.
