### PR TITLE
Translate "swipe_nav" in Bulgarian

### DIFF
--- a/source/js/Core/Language/locale/bg.js
+++ b/source/js/Core/Language/locale/bg.js
@@ -32,6 +32,6 @@ if(typeof VMM != 'undefined') {
 			wikipedia: "От Уикипедия, свободната енциклопедия",
 			loading_content: "Съдържанието се зарежда",
 			loading: "Зарежда се",
-			swipe_nav: "Swipe to Navigate"		}
+			swipe_nav: "Сменяйте с плъзгане настрани"		}
 	}
 }


### PR DESCRIPTION
The new key "swipe_nav" was not translated in Bulgarian.

"Swipe to navigate" has no good translation in Bulgarian. I've translated the rough meaning.