### PR TITLE
Https media type

### DIFF
--- a/source/js/Core/Media/VMM.MediaType.js
+++ b/source/js/Core/Media/VMM.MediaType.js
@@ -133,7 +133,7 @@ if(typeof VMM != 'undefined' && typeof VMM.MediaType == 'undefined') {
 			media.id = wiki_id.replace(" ", "%20");
 			media.lang = d.split("//")[1].split(".wikipedia")[0];
 			success = true;
-		} else if (d.indexOf('http://') == 0) {
+		} else if (d.indexOf('http://') == 0 || d.indexOf('https://') == 0) {
 			media.type = "website";
 			media.id = d;
 			success = true;


### PR DESCRIPTION
When a media url (json conf : assets / media) starting with https:// is parsed, the determined type is "unknown media" which leads to a plain text url in the timeline.