### PR TITLE
Add a better favicon.ico

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -26,7 +26,7 @@
     meta name="viewport" content="initial-scale=1,width=device-width" 
     someone needs to go through Blueline and fix the small viewport CSS details before we can turn this on.
   -->
-	<link rel="shortcut icon" href="//cdn.knightlab.com/libs/blueline/latest/assets/logos/favicon.ico"> 
+	<link rel="shortcut icon" href="//cdn.knightlab.com/favicon.ico"> 
     <link href="//cloud.webtype.com/css/d4767ecb-457a-4677-8761-72f890add836.css" rel="stylesheet" type="text/css">
 	<link rel="stylesheet" href="//cdn.knightlab.com/libs/blueline/latest/css/blueline.min.css">
 	<link rel="stylesheet" type="text/css" href="{{ static_url }}/css/site.css">


### PR DESCRIPTION
Use the favicon.ico for [knightlab.com](knightlab.com), which has a higher resolution and is more likely to be up to date.