### PR TITLE
Support for non-gregorian calendars date formatting

### DIFF
--- a/source/js/Core/Core/VMM.Calendar.js
+++ b/source/js/Core/Core/VMM.Calendar.js
@@ -1,0 +1,158 @@
+/*	* Default Gregorian Calendar Formatter
+================================================== */
+if(typeof VMM != 'undefined' && typeof VMM.Calendar == 'undefined') {
+	
+	/*
+	 * Date Format 1.2.3
+	 * (c) 2007-2009 Steven Levithan <stevenlevithan.com>
+	 * MIT license
+	 *
+	 * Includes enhancements by Scott Trenda <scott.trenda.net>
+	 * and Kris Kowal <cixar.com/~kris.kowal/>
+	 *
+	 * Accepts a date, a mask, or a date and a mask.
+	 * Returns a formatted version of the given date.
+	 * The date defaults to the current date/time.
+	 * The mask defaults to dateFormat.masks.default.
+	 */
+
+	var dateFormat = function () {
+		var	token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[WLloSZ]|"[^"]*"|'[^']*'/g,
+			timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,
+			timezoneClip = /[^-+\dA-Z]/g,
+			pad = function (val, len) {
+				val = String(val);
+				len = len || 2;
+				while (val.length < len) val = "0" + val;
+				return val;
+			};
+
+		// Regexes and supporting functions are cached through closure
+		return function (date, mask, utc) {
+			var dF = dateFormat;
+
+			// You can't provide utc if you skip other args (use the "UTC:" mask prefix)
+			if (arguments.length == 1 && Object.prototype.toString.call(date) == "[object String]" && !/\d/.test(date)) {
+				mask = date;
+				date = undefined;
+			}
+
+			// Passing date through Date applies Date.parse, if necessary
+			// Caused problems in IE
+			// date = date ? new Date(date) : new Date;
+			if (isNaN(date)) {
+				trace("invalid date " + date);
+				//return "";
+			} 
+
+			mask = String(dF.masks[mask] || mask || dF.masks["default"]);
+
+			// Allow setting the utc argument via the mask
+			if (mask.slice(0, 4) == "UTC:") {
+				mask = mask.slice(4);
+				utc = true;
+			}
+
+			var	_ = utc ? "getUTC" : "get",
+				d = date[_ + "Date"](),
+				D = date[_ + "Day"](),
+				m = date[_ + "Month"](),
+				y = date[_ + "FullYear"](),
+				H = date[_ + "Hours"](),
+				M = date[_ + "Minutes"](),
+				s = date[_ + "Seconds"](),
+				L = date[_ + "Milliseconds"](),
+				W = date.getWeek(),
+				o = utc ? 0 : date.getTimezoneOffset(),
+				flags = {
+					d:    d,
+					dd:   pad(d),
+					ddd:  dF.i18n.dayNames[D],
+					dddd: dF.i18n.dayNames[D + 7],
+					m:    m + 1,
+					mm:   pad(m + 1),
+					mmm:  dF.i18n.monthNames[m],
+					mmmm: dF.i18n.monthNames[m + 12],
+					yy:   String(y).slice(2),
+					yyyy: y,
+					h:    H % 12 || 12,
+					hh:   pad(H % 12 || 12),
+					H:    H,
+					HH:   pad(H),
+					M:    M,
+					MM:   pad(M),
+					s:    s,
+					ss:   pad(s),
+					l:    pad(L, 3),
+					L:    pad(L > 99 ? Math.round(L / 10) : L),
+					t:    H < 12 ? "a"  : "p",
+					tt:   H < 12 ? "am" : "pm",
+					T:    H < 12 ? "A"  : "P",
+					TT:   H < 12 ? "AM" : "PM",
+					Z:    utc ? "UTC" : (String(date).match(timezone) || [""]).pop().replace(timezoneClip, ""),
+					o:    (o > 0 ? "-" : "+") + pad(Math.floor(Math.abs(o) / 60) * 100 + Math.abs(o) % 60, 4),
+					S:    ["th", "st", "nd", "rd"][d % 10 > 3 ? 0 : (d % 100 - d % 10 != 10) * d % 10],
+					W: 	W
+				};
+
+			return mask.replace(token, function ($0) {
+				return $0 in flags ? flags[$0] : $0.slice(1, $0.length - 1);
+			});
+		};
+	}();
+
+	// Some common format strings
+	dateFormat.masks = {
+		"default":      "ddd mmm dd yyyy HH:MM:ss",
+		shortDate:      "m/d/yy",
+		mediumDate:     "mmm d, yyyy",
+		longDate:       "mmmm d, yyyy",
+		fullDate:       "dddd, mmmm d, yyyy",
+		shortTime:      "h:MM TT",
+		mediumTime:     "h:MM:ss TT",
+		longTime:       "h:MM:ss TT Z",
+		isoDate:        "yyyy-mm-dd",
+		isoTime:        "HH:MM:ss",
+		isoDateTime:    "yyyy-mm-dd'T'HH:MM:ss",
+		isoUtcDateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"
+	};
+
+	// Internationalization strings
+	dateFormat.i18n = {
+		dayNames: [
+			"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+			"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+		],
+		monthNames: [
+			"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+			"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+		]
+	};
+
+	// For convenience...
+	Date.prototype.format = function (mask, utc) {
+		return dateFormat(this, mask, utc);
+	};
+	
+	// ************************************************************************************************
+	
+	VMM.Calendar = ({
+		
+		init: function() {
+			return this;
+		},
+		
+		format: dateFormat,
+		
+		getFullYear: function(date) {
+			if ( date.getFullYear() < 0 ) {
+				return Math.abs( date.getFullYear() ).toString() + " B.C.";
+			} else {
+				return date.getFullYear();
+			}
+		}
+		
+	}).init();
+	
+}
+	

--- a/source/js/Core/Core/VMM.Core.js
+++ b/source/js/Core/Core/VMM.Core.js
@@ -8,6 +8,7 @@
 // @codekit-prepend "VMM.Library.js";
 // @codekit-prepend "VMM.Browser.js";
 // @codekit-prepend "VMM.FileExtention.js";
+// @codekit-prepend "VMM.Calendar.js";
 // @codekit-prepend "VMM.Date.js";
 // @codekit-prepend "VMM.Util.js";
 // @codekit-prepend "VMM.LoadLib.js";

--- a/source/js/Core/Core/VMM.Date.js
+++ b/source/js/Core/Core/VMM.Date.js
@@ -48,8 +48,8 @@ if(typeof VMM != 'undefined' && typeof VMM.Date == 'undefined') {
 			VMM.Date.month_abbr			=	lang.date.month_abbr;
 			VMM.Date.day				=	lang.date.day;
 			VMM.Date.day_abbr			=	lang.date.day_abbr;
-			dateFormat.i18n.dayNames	=	lang.date.day_abbr.concat(lang.date.day);
-			dateFormat.i18n.monthNames	=	lang.date.month_abbr.concat(lang.date.month);
+			VMM.Calendar.format.i18n.dayNames	=	lang.date.day_abbr.concat(lang.date.day);
+			VMM.Calendar.format.i18n.monthNames	=	lang.date.month_abbr.concat(lang.date.month);
 		},
 			
 		parse: function(d, precision) {
@@ -395,7 +395,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Date == 'undefined') {
 					}
 				}
 				
-				_date = dateFormat(d, format, false);
+				_date = VMM.Calendar.format(d, format, false);
 				//_date = "Jan"
 				bc_check = _date.split(" ");
 					
@@ -412,7 +412,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Date == 'undefined') {
 					
 					
 				if (is_pair) {
-					_date2 = dateFormat(d2, format, false);
+					_date2 = VMM.Calendar.format(d2, format, false);
 					bc_check = _date2.split(" ");
 					// BC TIME SUPPORT
 					for(var j = 0; j < bc_check.length; j++) {
@@ -439,137 +439,4 @@ if(typeof VMM != 'undefined' && typeof VMM.Date == 'undefined') {
 		}
 		
 	}).init();
-	
-	/*
-	 * Date Format 1.2.3
-	 * (c) 2007-2009 Steven Levithan <stevenlevithan.com>
-	 * MIT license
-	 *
-	 * Includes enhancements by Scott Trenda <scott.trenda.net>
-	 * and Kris Kowal <cixar.com/~kris.kowal/>
-	 *
-	 * Accepts a date, a mask, or a date and a mask.
-	 * Returns a formatted version of the given date.
-	 * The date defaults to the current date/time.
-	 * The mask defaults to dateFormat.masks.default.
-	 */
-
-	var dateFormat = function () {
-		var	token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[WLloSZ]|"[^"]*"|'[^']*'/g,
-			timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,
-			timezoneClip = /[^-+\dA-Z]/g,
-			pad = function (val, len) {
-				val = String(val);
-				len = len || 2;
-				while (val.length < len) val = "0" + val;
-				return val;
-			};
-
-		// Regexes and supporting functions are cached through closure
-		return function (date, mask, utc) {
-			var dF = dateFormat;
-
-			// You can't provide utc if you skip other args (use the "UTC:" mask prefix)
-			if (arguments.length == 1 && Object.prototype.toString.call(date) == "[object String]" && !/\d/.test(date)) {
-				mask = date;
-				date = undefined;
-			}
-
-			// Passing date through Date applies Date.parse, if necessary
-			// Caused problems in IE
-			// date = date ? new Date(date) : new Date;
-			if (isNaN(date)) {
-				trace("invalid date " + date);
-				//return "";
-			} 
-
-			mask = String(dF.masks[mask] || mask || dF.masks["default"]);
-
-			// Allow setting the utc argument via the mask
-			if (mask.slice(0, 4) == "UTC:") {
-				mask = mask.slice(4);
-				utc = true;
-			}
-
-			var	_ = utc ? "getUTC" : "get",
-				d = date[_ + "Date"](),
-				D = date[_ + "Day"](),
-				m = date[_ + "Month"](),
-				y = date[_ + "FullYear"](),
-				H = date[_ + "Hours"](),
-				M = date[_ + "Minutes"](),
-				s = date[_ + "Seconds"](),
-				L = date[_ + "Milliseconds"](),
-				W = date.getWeek(),
-				o = utc ? 0 : date.getTimezoneOffset(),
-				flags = {
-					d:    d,
-					dd:   pad(d),
-					ddd:  dF.i18n.dayNames[D],
-					dddd: dF.i18n.dayNames[D + 7],
-					m:    m + 1,
-					mm:   pad(m + 1),
-					mmm:  dF.i18n.monthNames[m],
-					mmmm: dF.i18n.monthNames[m + 12],
-					yy:   String(y).slice(2),
-					yyyy: y,
-					h:    H % 12 || 12,
-					hh:   pad(H % 12 || 12),
-					H:    H,
-					HH:   pad(H),
-					M:    M,
-					MM:   pad(M),
-					s:    s,
-					ss:   pad(s),
-					l:    pad(L, 3),
-					L:    pad(L > 99 ? Math.round(L / 10) : L),
-					t:    H < 12 ? "a"  : "p",
-					tt:   H < 12 ? "am" : "pm",
-					T:    H < 12 ? "A"  : "P",
-					TT:   H < 12 ? "AM" : "PM",
-					Z:    utc ? "UTC" : (String(date).match(timezone) || [""]).pop().replace(timezoneClip, ""),
-					o:    (o > 0 ? "-" : "+") + pad(Math.floor(Math.abs(o) / 60) * 100 + Math.abs(o) % 60, 4),
-					S:    ["th", "st", "nd", "rd"][d % 10 > 3 ? 0 : (d % 100 - d % 10 != 10) * d % 10],
-					W: 	W
-				};
-
-			return mask.replace(token, function ($0) {
-				return $0 in flags ? flags[$0] : $0.slice(1, $0.length - 1);
-			});
-		};
-	}();
-
-	// Some common format strings
-	dateFormat.masks = {
-		"default":      "ddd mmm dd yyyy HH:MM:ss",
-		shortDate:      "m/d/yy",
-		mediumDate:     "mmm d, yyyy",
-		longDate:       "mmmm d, yyyy",
-		fullDate:       "dddd, mmmm d, yyyy",
-		shortTime:      "h:MM TT",
-		mediumTime:     "h:MM:ss TT",
-		longTime:       "h:MM:ss TT Z",
-		isoDate:        "yyyy-mm-dd",
-		isoTime:        "HH:MM:ss",
-		isoDateTime:    "yyyy-mm-dd'T'HH:MM:ss",
-		isoUtcDateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"
-	};
-
-	// Internationalization strings
-	dateFormat.i18n = {
-		dayNames: [
-			"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
-			"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
-		],
-		monthNames: [
-			"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-			"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
-		]
-	};
-
-	// For convenience...
-	Date.prototype.format = function (mask, utc) {
-		return dateFormat(this, mask, utc);
-	};
-	
 }

--- a/source/js/Core/Embed/Embed.js
+++ b/source/js/Core/Embed/Embed.js
@@ -92,6 +92,7 @@ function createStoryJS(c, src) {
 			height:		'100%',
 			source:		'https://docs.google.com/spreadsheet/pub?key=0Agl_Dv6iEbDadFYzRjJPUGktY0NkWXFUWkVIZDNGRHc&output=html',
 			lang:		'en',
+			calendar:   'Gregorian',
 			font:		'default',
 			css:		path.css + 'timeline.css?'+js_version,
 			js:			'',
@@ -184,7 +185,12 @@ function createStoryJS(c, src) {
 		path.locale = path.locale + storyjs_e_config.lang + ".js?" + js_version;
 	}
 	
-		
+	/* PREPARE CALENDAR
+	================================================== */
+	if (storyjs_e_config.calendar != "Gregorian") {
+		path.calendar = storyjs_e_config.calendar;
+	}
+	
 	/* PREPARE
 	================================================== */
 	createEmbedDiv();
@@ -267,10 +273,21 @@ function createStoryJS(c, src) {
 		} else {
 			ready.language = true;
 		}
+		
+		if (storyjs_e_config.calendar != "Gregorian") {
+			LazyLoad.js(path.calendar, onloaded_calendar);
+		} else {
+			ready.calendar = true;
+		}
+	
 		onloaded_check();
 	}
 	function onloaded_language() {
 		ready.language = true;
+		onloaded_check();
+	}
+	function onloaded_calendar() {
+		ready.calendar = true;
 		onloaded_check();
 	}
 	function onloaded_css() {
@@ -291,7 +308,7 @@ function createStoryJS(c, src) {
 			alert("Error Loading Files");
 		} else {
 			ready.checks++;
-			if (ready.js && ready.css && ready.font.css && ready.font.js && ready.language) {
+			if (ready.js && ready.css && ready.font.css && ready.font.js && ready.language && ready.calendar) {
 				if (!ready.finished) {
 					ready.finished = true;
 					buildEmbed();

--- a/source/js/VMM.Timeline.TimeNav.js
+++ b/source/js/VMM.Timeline.TimeNav.js
@@ -1205,11 +1205,7 @@ if(typeof VMM.Timeline != 'undefined' && typeof VMM.Timeline.TimeNav == 'undefin
 				}
 				
 				if (_is_year) {
-					if ( int_obj.date.getFullYear() < 0 ) {
-						int_obj.date_string = 	Math.abs( int_obj.date.getFullYear() ).toString() + " B.C.";
-					} else {
-						int_obj.date_string = int_obj.date.getFullYear();
-					}
+					int_obj.date_string = VMM.Calendar.getFullYear(int_obj.date);
 				} else {
 					int_obj.date_string = VMM.Date.prettyDate(int_obj.date, true);
 				}


### PR DESCRIPTION
With this change, i can provide the timeline with the javascript stategy i want to render the dates, by indicating the url of the js file that has that logic in the "calendar" attribute of the timeline config.

I think this is a useful feature, i remember somebody needing a hebrew calendar and there is also the question in the faq about using relative times (1 month, 2 months, etc) rather than absolute dates. This is useful for both cases.

In a couple of days i might be able to implement a couple of examples.