### PR TITLE
fix  "nothing?callback=onJSONP_Data" 404 (Not Found) error

### DIFF
--- a/build/js/timeline.js
+++ b/build/js/timeline.js
@@ -531,7 +531,9 @@ if(typeof VMM != 'undefined') {
 					var colon = url.indexOf(':');
 					url = url.substr(colon+1); 
 			}
-			return jQuery.getJSON(url, data, callback);
+			return jQuery.ajax(url, data, callback);
+			//JSG 2015.Aug.24 changed from getJSON to ajax based on:
+			//http://stackoverflow.com/questions/1002367/jquery-ajax-jsonp-ignores-a-timeout-and-doesnt-fire-the-error-event
 
 		}
 	}
@@ -7349,7 +7351,7 @@ if(typeof VMM != 'undefined' && typeof VMM.Timeline == 'undefined') {
 			createConfig(c);
 			createStructure();
 			
-			if (type.of(_data) == "string") {
+			if (type.of(_data) == "string" || type.of(_data) == "object") {
 				config.source	= _data;
 			}
 			

--- a/build/js/timeline.js
+++ b/build/js/timeline.js
@@ -531,8 +531,8 @@ if(typeof VMM != 'undefined') {
 					var colon = url.indexOf(':');
 					url = url.substr(colon+1); 
 			}
-			return jQuery.ajax(url, data, callback);
-			//JSG 2015.Aug.24 changed from getJSON to ajax based on:
+			return jQuery.getJSON(url, data, callback);
+			//JSG 2015.Aug.24 return jQuery.ajax(url, data, callback); changed from getJSON to ajax based on:
 			//http://stackoverflow.com/questions/1002367/jquery-ajax-jsonp-ignores-a-timeout-and-doesnt-fire-the-error-event
 
 		}


### PR DESCRIPTION
When trying to update recline and timemapper to the most recent TimelineJS, i was getting a 404 (Not Found) error relating to a final getJSON call to "nothing?callback=onJSONP_Data" 
Investigation showed that the data was already received, but not being added to the config.source, which resulted in a call to "nothing" the default source on the config object.

additionally I changed to the ajax call rather than getJSON based on the advice of the article that I cited in the comment:
http://stackoverflow.com/questions/1002367/jquery-ajax-jsonp-ignores-a-timeout-and-doesnt-fire-the-error-event

This seemed to work inside timemapper, but broke the timelineJS test:
http://recline.1zm.in/vendor/TimelineJS2/tests/test_extra_html.html

So i rolled it back to still use getJSON... I left the comment in there to start a discussion... what are the advantages of getJSON? do you agree in general with the advice from Husky on that stackoverflow link?

cheers,
gotjoshua